### PR TITLE
Add FixedVariablesSet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+Manifest.toml
 *.jl.cov
 *.jl.*.cov
 *.jl.mem

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,14 @@
 ## Documentation: http://docs.travis-ci.com/user/languages/julia/
 language: julia
+codecov: true
+coveralls: true
 os:
   - linux
   - osx
 julia:
-  - 0.7
   - 1.0
+  - 1.1
 notifications:
   email: false
 git:
   depth: 99999999
-
-after_success:
-  - julia -e 'using Pkg; Pkg.add("Coverage"); cd(Pkg.dir("SemialgebraicSets")); using Coverage; Coveralls.submit(process_folder()); Coveralls.submit(process_folder()); Codecov.submit(process_folder())'

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,20 @@
+name = "SemialgebraicSets"
+uuid = "8e049039-38e8-557d-ae3a-bc521ccf6204"
+repo = "https://github.com/JuliaAlgebra/SemialgebraicSets.jl.git"
+version = "0.1.0"
+
+[deps]
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+MultivariatePolynomials = "102ac46a-7ee4-5c85-9060-abc95bfdeaa3"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[compat]
+MultivariatePolynomials = "0.3"
+julia = "1"
+
+[extras]
+DynamicPolynomials = "7c1d4256-1411-5781-91ec-d7bc3513ac07"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test", "DynamicPolynomials"]

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,0 @@
-julia 0.7
-MultivariatePolynomials 0.1.0
-Compat 1.0

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 environment:
   matrix:
-  - julia_version: 0.7
   - julia_version: 1.0
+  - julia_version: 1.1
 
 platform:
   - x86 # 32-bit

--- a/src/SemialgebraicSets.jl
+++ b/src/SemialgebraicSets.jl
@@ -1,9 +1,6 @@
-__precompile__()
-
 module SemialgebraicSets
 
-using Compat
-using Compat.Random
+using Random
 
 using MultivariatePolynomials
 const MP = MultivariatePolynomials
@@ -27,7 +24,15 @@ function Base.show(io::IO, ::FullSpace)
     print(io, "R^n")
 end
 
-Base.intersect(S::AbstractSemialgebraicSet, T::AbstractSemialgebraicSet, U::AbstractSemialgebraicSet...) = intersect(intersect(S, T), U...)
+Base.intersect(S::FullSpace, T::AbstractSemialgebraicSet) = T
+Base.intersect(S::AbstractSemialgebraicSet, T::FullSpace) = S
+Base.intersect(S::FullSpace, T::FullSpace) = S
+
+# If `intersect(S, T)` is not implemented, this method will `StackOverflow`.
+Base.intersect(S::AbstractSemialgebraicSet, T::AbstractSemialgebraicSet, args...; kws...) = intersect(intersect(S, T), args...; kws...)
+# The keywords are only used when transforming `Element`
+# into `BasicSemialgebraicSet`.
+Base.intersect(set::AbstractSemialgebraicSet; kws...) = set
 
 include("groebner.jl")
 include("ideal.jl")
@@ -35,6 +40,7 @@ include("solve.jl")
 include("variety.jl")
 include("basic.jl")
 
+include("fix.jl")
 include("macro.jl")
 
 end # module

--- a/src/basic.jl
+++ b/src/basic.jl
@@ -1,13 +1,16 @@
 export inequalities, basicsemialgebraicset
 
-struct BasicSemialgebraicSet{T, PT<:APL{T}, AT <: AlgebraicSet{T, PT}} <: AbstractBasicSemialgebraicSet
+struct BasicSemialgebraicSet{T, PT<:APL{T}, AT <: AbstractAlgebraicSet} <: AbstractBasicSemialgebraicSet
     V::AT
     p::Vector{PT}
 end
 function BasicSemialgebraicSet{T, PT}() where {T, PT<:APL{T}}
     BasicSemialgebraicSet(AlgebraicSet{T, PT}(), PT[])
 end
-function BasicSemialgebraicSet(V::AlgebraicSet{T, PT, A, S}, p::Vector{PS}) where {T, PT, PS, A, S}
+function BasicSemialgebraicSet(V::AlgebraicSet{T, PT, A, S}, p::Vector{PT}) where {T, PT<:APL, A, S}
+    BasicSemialgebraicSet{T, PT, typeof(V)}(V, p)
+end
+function BasicSemialgebraicSet(V::AlgebraicSet{T, PT, A, S}, p::Vector{PS}) where {T, PT<:APL, PS<:APL, A, S}
     PU = promote_type(PT, PS)
     BasicSemialgebraicSet(convert(AlgebraicSet{T, PU, A, S}, V), Vector{PU}(p))
 end
@@ -21,6 +24,6 @@ addequality!(S::BasicSemialgebraicSet, p) = addequality!(S.V, p)
 inequalities(S::BasicSemialgebraicSet) = S.p
 addinequality!(S::BasicSemialgebraicSet, p) = push!(S.p, p)
 
-Base.intersect(S::BasicSemialgebraicSet, T::BasicSemialgebraicSet) = BasicSemialgebraicSet(S.V ∩ T.V, [S.p; T.p])
-Base.intersect(S::BasicSemialgebraicSet, T::AlgebraicSet) = BasicSemialgebraicSet(S.V ∩ T, copy(S.p))
-Base.intersect(T::AlgebraicSet, S::BasicSemialgebraicSet) = intersect(S, T)
+Base.intersect(S::BasicSemialgebraicSet, T::BasicSemialgebraicSet) = intersect(BasicSemialgebraicSet(S.V ∩ T.V, [S.p; T.p]))
+Base.intersect(S::BasicSemialgebraicSet, T::AbstractAlgebraicSet) = intersect(BasicSemialgebraicSet(S.V ∩ T, copy(S.p)))
+Base.intersect(T::AbstractAlgebraicSet, S::BasicSemialgebraicSet) = intersect(S, T)

--- a/src/fix.jl
+++ b/src/fix.jl
@@ -1,0 +1,107 @@
+export FixedVariablesSet
+
+struct FixedVariablesIdeal{V<:AbstractVariable, T<:Number, MT<:AbstractMonomialLike} <: AbstractPolynomialIdeal
+    substitutions::Union{Nothing, Dict{V, T}}
+end
+# In that case, the ideal can generate any polynomial.
+function generate_nonzero_constant(I::FixedVariablesIdeal)
+    return I.substitutions === nothing
+end
+function Base.rem(p::AbstractPolynomialLike, I::FixedVariablesIdeal)
+    if generate_nonzero_constant(I)
+        return zero(p)
+    else
+        substitutions = [key => value for (key, value) in I.substitutions]
+        return subs(p, substitutions...)
+    end
+end
+
+struct FixedVariablesSet{V, T, MT} <: AbstractAlgebraicSet
+    ideal::FixedVariablesIdeal{V, T, MT}
+end
+ideal(set::FixedVariablesSet, args...) = set.ideal
+function nequalities(set::FixedVariablesSet)
+    if set.ideal.substitutions === nothing
+        return 1
+    else
+        return length(set.ideal.substitutions)
+    end
+end
+function equalities(set::FixedVariablesSet{V, T, MT}) where {V, T, MT}
+    if set.ideal.substitutions === nothing
+        return [constantterm(one(T), MT)]
+    else
+        return [key - value for (key, value) in set.ideal.substitutions]
+    end
+end
+function Base.intersect(V::FixedVariablesSet{V1, T1, MT1}, W::FixedVariablesSet{V2, T2, MT2}) where {V1, V2, T1, T2, MT1, MT2}
+    # For `DynamicPolynomials`, they have the same type and for
+    # `TypedPolynomials`, promoting would give `Monomial`.
+    VT = V1 == V2 ? V1 : AbstractVariable
+    T = promote_type(T1, T2)
+    if V.ideal.substitutions === nothing || W.ideal.substitutions === nothing
+        sub = nothing
+    else
+        has_dup = false
+        function combine(a, b)
+            if a != b
+                has_dup = true
+            end
+            return a
+        end
+        sub = Dict{VT, T}()
+        merge!(combine, sub, V.ideal.substitutions)
+        merge!(combine, sub, W.ideal.substitutions)
+        if has_dup
+            sub = nothing
+        end
+    end
+    ideal = FixedVariablesIdeal{VT, T, promote_type(MT1, MT2)}(sub)
+    return FixedVariablesSet(ideal)
+end
+function Base.intersect(V::AlgebraicSet, W::FixedVariablesSet)
+    return V ∩ algebraicset(W)
+end
+function Base.intersect(V::FixedVariablesSet, W::AlgebraicSet)
+    # Need `W` to be first so that the intersection uses its solver.
+    # and not the default one taken in `algebraicset(W)`.
+    return W ∩ V
+end
+
+iszerodimensional(::FixedVariablesSet) = true
+function Base.isempty(V::FixedVariablesSet)
+    return generate_nonzero_constant(V.ideal)
+end
+
+# Assumes `isempty(V)`
+function only_point(V::FixedVariablesSet)
+    subs = collect(V.ideal.substitutions)
+    sort!(subs, rev = true, by = sub -> sub[1])
+    return [sub[2] for sub in subs]
+end
+
+function Base.iterate(V::FixedVariablesSet, state=nothing)
+    if state === nothing && !isempty(V)
+        return only_point(V), true
+    else
+        return nothing
+    end
+end
+Base.length(V::FixedVariablesSet) = isempty(V) ? 0 : 1
+
+struct FixedVariable{V<:AbstractVariable, T}
+    variable::V
+    value::T
+end
+function equality(variable::AbstractVariable, value::Number)
+    return FixedVariable(variable, value)
+end
+function equality(value::Number, variable::AbstractVariable)
+    return FixedVariable(variable, value)
+end
+
+function Base.intersect(el::FixedVariable; kws...)
+    subs = Dict(el.variable => el.value)
+    return FixedVariablesSet(FixedVariablesIdeal{
+        typeof(el.variable), typeof(el.value), typeof(el.variable)}(subs))
+end

--- a/src/ideal.jl
+++ b/src/ideal.jl
@@ -1,11 +1,8 @@
-import Base: +
-
 export monomialbasis, ideal
 
 abstract type AbstractPolynomialIdeal end
 
-struct EmptyPolynomialIdeal
-end
+struct EmptyPolynomialIdeal <: AbstractPolynomialIdeal end
 ideal(p::FullSpace, algo=defaultgröbnerbasisalgorithm(p)) = EmptyPolynomialIdeal()
 Base.rem(p::AbstractPolynomialLike, I::EmptyPolynomialIdeal) = p
 
@@ -27,7 +24,7 @@ end
 
 ideal(p, algo=defaultgröbnerbasisalgorithm(p)) = PolynomialIdeal(p, algo)
 
-(+)(I::PolynomialIdeal, J::PolynomialIdeal) = PolynomialIdeal([I.p; J.p], I.algo)
+Base.:+(I::PolynomialIdeal, J::PolynomialIdeal) = PolynomialIdeal([I.p; J.p], I.algo)
 
 MP.variables(I::PolynomialIdeal) = variables(I.p)
 

--- a/src/schur.jl
+++ b/src/schur.jl
@@ -1,7 +1,7 @@
-import Compat.LinearAlgebra: Schur, BlasInt, checksquare, chkstride1
-import Compat.LinearAlgebra.LAPACK: liblapack, chklapackerror, @blasfunc
+import LinearAlgebra: Schur, BlasInt, checksquare, chkstride1
+import LinearAlgebra.LAPACK: liblapack, chklapackerror, @blasfunc
 
-using Compat.LinearAlgebra
+using LinearAlgebra
 
 if VERSION <= v"0.7-"
     # Taken from JuliaLang/julia/base/linalg/lapack.jl and fixed for compq == 'E'

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -92,11 +92,11 @@ include("schur.jl")
 """
 Corless, R. M.; Gianni, P. M. & Trager, B. M. A reordered Schur factorization method for zero-dimensional polynomial systems with multiple roots Proceedings of the 1997 international symposium on Symbolic and algebraic computation, 1997, 133-140
 """
-struct ReorderedSchurMultiplicationMatricesSolver{T, RNGT <: Compat.Random.AbstractRNG} <: AbstractMultiplicationMatricesSolver
+struct ReorderedSchurMultiplicationMatricesSolver{T, RNGT <: Random.AbstractRNG} <: AbstractMultiplicationMatricesSolver
     ɛ::T
     rng::RNGT
 end
-ReorderedSchurMultiplicationMatricesSolver(ɛ) = ReorderedSchurMultiplicationMatricesSolver(ɛ, Compat.Random.GLOBAL_RNG)
+ReorderedSchurMultiplicationMatricesSolver(ɛ) = ReorderedSchurMultiplicationMatricesSolver(ɛ, Random.GLOBAL_RNG)
 ReorderedSchurMultiplicationMatricesSolver{T}() where T = ReorderedSchurMultiplicationMatricesSolver(Base.rtoldefault(real(T)))
 
 function solvemultiplicationmatrices(Ms::AbstractVector{<:AbstractMatrix{T}}, solver::ReorderedSchurMultiplicationMatricesSolver) where T

--- a/src/variety.jl
+++ b/src/variety.jl
@@ -41,6 +41,9 @@ equalities(V::AlgebraicSet) = V.I.p
 addequality!(V::AlgebraicSet, p) = push!(V.I.p, p)
 Base.intersect(S::AlgebraicSet, T::AlgebraicSet) = AlgebraicSet(S.I + T.I, S.solver)
 
+function algebraicset(set::AbstractAlgebraicSet, solver...)
+    return algebraicset(equalities(set), solver...)
+end
 function Base.show(io::IO, V::AbstractAlgebraicSet)
     print(io, "Algebraic Set defined by ")
     n = nequalities(V)

--- a/test/macro.jl
+++ b/test/macro.jl
@@ -1,25 +1,86 @@
+struct DummySolver <: SemialgebraicSets.AbstractAlgebraicSolver end
+
 @testset "Basic semialgebraic set" begin
     Mod.@polyvar x y
     @test isa(FullSpace(), FullSpace)
     V = @set x * y == 1
     @test V isa AlgebraicSet
     @test_throws ArgumentError addinequality!(V, x*y)
-    S = @set x == 0 && x^2*y >= 1
-    addequality!(S, x^2 - y)
-    addinequality!(S, x + y - 1)
-    @test S isa BasicSemialgebraicSet
-    @test BasicSemialgebraicSet{Int, polynomialtype(x, Int)}() isa BasicSemialgebraicSet{Float64, polynomialtype(x, Float64)}
-    @test Int32(2)*x^2*y isa MultivariatePolynomials.AbstractTerm{Int32}
-    S = (@set Int32(2)*x^2*y == 0 && 1.0x^2*y >= 0 && (6//3)*x^2*y == -y && 1.5x+y >= 0)
-    S2 = S ∩ V
-    S3 = V ∩ S
-    @test inequalities(S2) == inequalities(S3) == S.p
-    @test equalities(S2) == S3.V.I.p
-    T = (@set x*y^2 == -1 && x^2 + y^2 <= 1)
-    V2 = @set T.V && V && x + y == 2.0
-    @test V2 isa AlgebraicSet
-    @test V2.I.p == [x + y - 2.0; equalities(T); equalities(V)]
-    S4 = @set S && T
-    @test S4.p == [S.p; inequalities(T)]
-    @test equalities(S4) == [S.V.I.p; T.V.I.p]
+    @testset "Basic" begin
+        S = @set x - y == 0 && x^2*y >= 1
+        addequality!(S, x^2 - y)
+        addinequality!(S, x + y - 1)
+        @test S isa BasicSemialgebraicSet
+        @test Int32(2)*x^2*y isa MultivariatePolynomials.AbstractTerm{Int32}
+
+        @testset "Mixed types" begin
+            S = (@set Int32(2)*x^2*y == 0 && 1.0x^2*y >= 0 && (6//3)*x^2*y == -y && 1.5x+y >= 0)
+            S2 = S ∩ V
+            S3 = V ∩ S
+            @test inequalities(S2) == inequalities(S3) == S.p
+            @test equalities(S2) == S3.V.I.p
+        end
+
+        T = (@set x*y^2 == -1 && x^2 + y^2 <= 1)
+        V2 = @set T.V && V && x + y == 2.0
+        @test V2 isa AlgebraicSet
+        @test V2.I.p == [equalities(T); equalities(V); x + y - 2.0]
+        S4 = @set S && T
+        @test S4.p == [S.p; inequalities(T)]
+        @test equalities(S4) == [S.V.I.p; T.V.I.p]
+    end
+    @testset "Basic with no equality" begin
+        S = @set x + y ≥ 1 && x ≤ y
+        @test S isa BasicSemialgebraicSet
+        @test S.V isa FullSpace
+    end
+    @testset "Basic with fixed variables" begin
+        S = @set x == 1 && x ≤ y && 2 == y
+        @test S isa BasicSemialgebraicSet
+        @test S.V isa FixedVariablesSet
+        @test rem(x + y, ideal(S.V)) == 3
+
+        S = @set x == 1 && x ≤ y && 2 == y && 1 == x
+        @test S isa BasicSemialgebraicSet
+        @test S.V isa FixedVariablesSet
+        @test rem(x + y, ideal(S.V)) == 3
+
+        @testset "Empty" begin
+            for S in (@set(x == 1 && x ≤ y && 2 == y && 2 == x),
+                      @set(x == 1 && x ≤ y && 2 == x),
+                      @set(x == 1 && x ≤ y && 2 == x && y == 3),
+                      @set(x ≤ y && y == 3 && x == 1 && y == 1),
+                      @set(x ≤ y && y == 3 && x == 1 && y == 3 && x == 2))
+                @test S isa BasicSemialgebraicSet
+                @test S.V isa FixedVariablesSet
+                @test isempty(S.V)
+                @test iszero(length(S.V))
+                @test isempty(collect(S.V))
+                @test iszero(rem(x + y, ideal(S.V)))
+            end
+        end
+    end
+    @testset "Basic mixed fixed variables and equalities" begin
+        for S in [@set(x == 1 && x ≤ y && 2 + y == x),
+                  @set(x == 1 && 2 + y == x && x ≤ y),
+                  @set(x ≤ y && 2 + y == x && x == 1),
+                  @set(x ≤ y && x == 1 && 2 + y == x),
+                  @set(2 + y == x && x ≤ y && x == 1),
+                  @set(2 + y == x && x ≤ y && x == 1)]
+            @test S isa BasicSemialgebraicSet
+            @test S.V isa AlgebraicSet
+        end
+
+        solver = DummySolver()
+        for S in [@set(x == 1 && x ≤ y && 2 + y == x, solver),
+                  @set(x == 1 && 2 + y == x && x ≤ y, solver),
+                  @set(x ≤ y && 2 + y == x && x == 1, solver),
+                  @set(x ≤ y && x == 1 && 2 + y == x, solver),
+                  @set(2 + y == x && x ≤ y && x == 1, solver),
+                  @set(2 + y == x && x ≤ y && x == 1, solver)]
+            @test S isa BasicSemialgebraicSet
+            @test S.V isa AlgebraicSet
+            @test S.V.solver === solver
+        end
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,5 @@
 using SemialgebraicSets
-using Compat
-using Compat.Test
+using Test
 
 using MultivariatePolynomials
 

--- a/test/solve.jl
+++ b/test/solve.jl
@@ -7,7 +7,7 @@
 # Manocha, D. & Demmel, J. Algorithms for intersecting parametric and algebraic curves II: multiple intersections
 # Graphical Models and Image Processing, Elsevier, 1995, 57, 81-100
 
-using Compat.LinearAlgebra # for I
+using LinearAlgebra # for I
 @testset "Section 4.1 MD95" begin
     η = 1e-10
     A = [zeros(10, 1) Matrix(I, 10, 10); zeros(1, 10) 0.5]
@@ -34,7 +34,7 @@ function testelements(X, Y; atol=Base.rtoldefault(Float64), kwargs...)
 end
 
 # We use a fixed RNG in the tests to decrease nondeterminism. There is still nondeterminism in LAPACK though
-using Compat.Random
+using Random
 solver = ReorderedSchurMultiplicationMatricesSolver(sqrt(eps(Float64)), MersenneTwister(0))
 
 @testset "Zero-dimensional ideal" begin


### PR DESCRIPTION
Before, `@set` was always using an `AlgebraicSet` for the equalities. Now, it uses
* `FullSpace` if there is no equality,
* `FixedVariablesSet` if the equalities are only fixing variable values, e.g. `x == 1`,
* `AlgebraicSet` otherwise.

For the first two, computing `rem` over the ideal is way faster so it might drastically speed up model generation for [SumOfSquares](https://github.com/JuliaOpt/SumOfSquares.jl) for the first two cases.

cc @tweisser