### PR TITLE
delete methods to remove ambiguities

### DIFF
--- a/src/basic.jl
+++ b/src/basic.jl
@@ -24,6 +24,9 @@ MP.changecoefficienttype(::Type{BasicSemialgebraicSet{S, PS, AT}}, T::Type) wher
 function Base.convert(::Type{BasicSemialgebraicSet{T, PT, AT}}, set::BasicSemialgebraicSet{T, PT, AT}) where {T, PT<:APL, AT<:AbstractAlgebraicSet}
     return set
 end
+function Base.convert(::Type{BasicSemialgebraicSet{T, PT, AT}}, set::BasicSemialgebraicSet{T, PT, AT}) where {T, PT<:AbstractPolynomialLike{T}, AT<:AbstractAlgebraicSet}
+    return set
+end
 function Base.convert(::Type{BasicSemialgebraicSet{T, PT, AT}}, set::BasicSemialgebraicSet) where {T, PT, AT}
     return BasicSemialgebraicSet{T, PT, AT}(set.V, set.p)
 end

--- a/src/basic.jl
+++ b/src/basic.jl
@@ -16,6 +16,9 @@ function BasicSemialgebraicSet(V::AlgebraicSet{T, PT, A, ST}, p::Vector{PS}) whe
     BasicSemialgebraicSet(convert(AlgebraicSet{U, PU, A, ST}, V), Vector{PU}(p))
 end
 #BasicSemialgebraicSet{T, PT<:APL{T}}(V::AlgebraicSet{T, PT}, p::Vector{PT}) = BasicSemialgebraicSet{T, PT}(V, p)
+function basicsemialgebraicset(V, p)
+    BasicSemialgebraicSet(V, p)
+end
 
 MP.changecoefficienttype(::Type{BasicSemialgebraicSet{S, PS, AT}}, T::Type) where {S, PS, AT} = BasicSemialgebraicSet{T, MP.changecoefficienttype(PS, T), MP.changecoefficienttype(AT, T)}
 

--- a/src/basic.jl
+++ b/src/basic.jl
@@ -16,17 +16,9 @@ function BasicSemialgebraicSet(V::AlgebraicSet{T, PT, A, ST}, p::Vector{PS}) whe
     BasicSemialgebraicSet(convert(AlgebraicSet{U, PU, A, ST}, V), Vector{PU}(p))
 end
 #BasicSemialgebraicSet{T, PT<:APL{T}}(V::AlgebraicSet{T, PT}, p::Vector{PT}) = BasicSemialgebraicSet{T, PT}(V, p)
-function basicsemialgebraicset(V, p)
-    BasicSemialgebraicSet(V, p)
-end
 
 MP.changecoefficienttype(::Type{BasicSemialgebraicSet{S, PS, AT}}, T::Type) where {S, PS, AT} = BasicSemialgebraicSet{T, MP.changecoefficienttype(PS, T), MP.changecoefficienttype(AT, T)}
-function Base.convert(::Type{BasicSemialgebraicSet{T, PT, AT}}, set::BasicSemialgebraicSet{T, PT, AT}) where {T, PT<:APL, AT<:AbstractAlgebraicSet}
-    return set
-end
-function Base.convert(::Type{BasicSemialgebraicSet{T, PT, AT}}, set::BasicSemialgebraicSet{T, PT, AT}) where {T, PT<:AbstractPolynomialLike{T}, AT<:AbstractAlgebraicSet}
-    return set
-end
+
 function Base.convert(::Type{BasicSemialgebraicSet{T, PT, AT}}, set::BasicSemialgebraicSet) where {T, PT, AT}
     return BasicSemialgebraicSet{T, PT, AT}(set.V, set.p)
 end

--- a/test/macro.jl
+++ b/test/macro.jl
@@ -12,6 +12,7 @@ struct DummySolver <: SemialgebraicSets.AbstractAlgebraicSolver end
         addinequality!(S, x + y - 1)
         # Algebraic set forces `Float64`
         @test S isa BasicSemialgebraicSet{Float64}
+        @test S == basicsemialgebraicset(S.V, S.p)
         @test sprint(show, S) == "{ (x, y) | x - y = 0, x^2 - y = 0, x^2*y - 1.0 ≥ 0, x + y - 1.0 ≥ 0 }"
         @test sprint(show, MIME"text/plain"(), S) == "Basic semialgebraic Set defined by 2 equalities\n x - y = 0\n x^2 - y = 0\n2 inequalities\n x^2*y - 1.0 ≥ 0\n x + y - 1.0 ≥ 0\n"
         @test S.V isa AlgebraicSet{Float64}


### PR DESCRIPTION
fixes #16 
I added the method that was "suggested by Julia" when the ambiguity error is thrown, though I don't actually understand why we are going into `convert` from places like https://github.com/jump-dev/SumOfSquares.jl/blob/master/src/sos_polynomial.jl#L46, or if this should be considered a Julia issue?
This should probably be tested on more Julia versions in the CI scripts.